### PR TITLE
feat: 이번 달 달력 멀티데이 바 레이아웃 개선

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_color_column_to_schedule.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_color_column_to_schedule.py
@@ -1,0 +1,28 @@
+"""add color column to schedule
+
+Revision ID: a1b2c3d4e5f6
+Revises: 8df204b49245
+Create Date: 2026-02-02 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = '8df204b49245'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add color column to schedule table
+    op.add_column('schedule', sa.Column('color', sa.String(20), nullable=True))
+
+
+def downgrade() -> None:
+    # Remove color column from schedule table
+    op.drop_column('schedule', 'color')

--- a/backend/alembic/versions/a1b2c3d4e5f6_add_color_column_to_schedule.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_color_column_to_schedule.py
@@ -1,7 +1,7 @@
 """add color column to schedule
 
 Revision ID: a1b2c3d4e5f6
-Revises: 8df204b49245
+Revises: b2c3d4e5f6g7
 Create Date: 2026-02-02 12:00:00.000000
 
 """
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'a1b2c3d4e5f6'
-down_revision: Union[str, None] = '8df204b49245'
+down_revision: Union[str, None] = 'b2c3d4e5f6g7'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/db/seed_data.py
+++ b/backend/app/db/seed_data.py
@@ -39,51 +39,51 @@ def get_seed_schedules():
     # ========================================
     hackathon_schedules = [
         # Day 1 (1/5 월) - 교육 준비
-        {"title": "IBM AI 해커톤 오프닝", "category": "activity", "start": (1, 5, 9, 30), "end": (1, 5, 10, 30), "priority": 5, "text": "강릉원주대 x 강원대학교 AI 개발자 해커톤"},
-        {"title": "Design Thinking Workshop", "category": "activity", "start": (1, 5, 10, 30), "end": (1, 5, 11, 30), "priority": 4},
-        {"title": "Innovation Studio Tour & AI 특강", "category": "activity", "start": (1, 5, 13, 0), "end": (1, 5, 13, 50), "priority": 4},
-        {"title": "생성형 AI 개념 이해", "category": "activity", "start": (1, 5, 13, 50), "end": (1, 5, 14, 40), "priority": 4},
-        {"title": "IBM watsonx platform 이해", "category": "activity", "start": (1, 5, 15, 0), "end": (1, 5, 15, 50), "priority": 4},
-        {"title": "실습개발환경 준비", "category": "activity", "start": (1, 5, 16, 0), "end": (1, 5, 17, 30), "priority": 4},
+        {"title": "IBM AI 해커톤 오프닝", "category": "activity", "start": (1, 5, 9, 30), "end": (1, 5, 10, 30), "priority": 5, "text": "강릉원주대 x 강원대학교 AI 개발자 해커톤", "color": "#4F8CFF"},
+        {"title": "Design Thinking Workshop", "category": "activity", "start": (1, 5, 10, 30), "end": (1, 5, 11, 30), "priority": 4, "color": "#4F8CFF"},
+        {"title": "Innovation Studio Tour & AI 특강", "category": "activity", "start": (1, 5, 13, 0), "end": (1, 5, 13, 50), "priority": 4, "color": "#4F8CFF"},
+        {"title": "생성형 AI 개념 이해", "category": "activity", "start": (1, 5, 13, 50), "end": (1, 5, 14, 40), "priority": 4, "color": "#4F8CFF"},
+        {"title": "IBM watsonx platform 이해", "category": "activity", "start": (1, 5, 15, 0), "end": (1, 5, 15, 50), "priority": 4, "color": "#4F8CFF"},
+        {"title": "실습개발환경 준비", "category": "activity", "start": (1, 5, 16, 0), "end": (1, 5, 17, 30), "priority": 4, "color": "#4F8CFF"},
         
         # Day 2 (1/6 화) - 생성형 AI 실습
-        {"title": "Prompt Engineering 개념 이해", "category": "activity", "start": (1, 6, 9, 30), "end": (1, 6, 10, 30), "priority": 4, "text": "생성형 AI 실습"},
-        {"title": "Prompt Engineering 실습", "category": "activity", "start": (1, 6, 10, 30), "end": (1, 6, 11, 30), "priority": 4},
-        {"title": "생성형 AI를 활용한 서비스 구현 방안 이해 및 실습", "category": "activity", "start": (1, 6, 13, 0), "end": (1, 6, 13, 50), "priority": 4},
-        {"title": "RAG Pattern 개념 이해 및 실습", "category": "activity", "start": (1, 6, 13, 50), "end": (1, 6, 14, 40), "priority": 4},
-        {"title": "Vector DB 이해 및 실습", "category": "activity", "start": (1, 6, 15, 0), "end": (1, 6, 15, 50), "priority": 4},
-        {"title": "서비스 개발 및 배포 환경 이해", "category": "activity", "start": (1, 6, 16, 0), "end": (1, 6, 17, 0), "priority": 4},
-        {"title": "조별과제 논의", "category": "team", "start": (1, 6, 17, 0), "end": (1, 6, 17, 30), "priority": 3},
+        {"title": "Prompt Engineering 개념 이해", "category": "activity", "start": (1, 6, 9, 30), "end": (1, 6, 10, 30), "priority": 4, "text": "생성형 AI 실습", "color": "#9B7EFF"},
+        {"title": "Prompt Engineering 실습", "category": "activity", "start": (1, 6, 10, 30), "end": (1, 6, 11, 30), "priority": 4, "color": "#9B7EFF"},
+        {"title": "생성형 AI를 활용한 서비스 구현 방안 이해 및 실습", "category": "activity", "start": (1, 6, 13, 0), "end": (1, 6, 13, 50), "priority": 4, "color": "#9B7EFF"},
+        {"title": "RAG Pattern 개념 이해 및 실습", "category": "activity", "start": (1, 6, 13, 50), "end": (1, 6, 14, 40), "priority": 4, "color": "#9B7EFF"},
+        {"title": "Vector DB 이해 및 실습", "category": "activity", "start": (1, 6, 15, 0), "end": (1, 6, 15, 50), "priority": 4, "color": "#9B7EFF"},
+        {"title": "서비스 개발 및 배포 환경 이해", "category": "activity", "start": (1, 6, 16, 0), "end": (1, 6, 17, 0), "priority": 4, "color": "#9B7EFF"},
+        {"title": "조별과제 논의", "category": "team", "start": (1, 6, 17, 0), "end": (1, 6, 17, 30), "priority": 3, "color": "#7ED957"},
         
         # Day 3 (1/7 수) - Agentic AI 실습
-        {"title": "생성형 AI 유즈 케이스 기반 실습 1", "category": "activity", "start": (1, 7, 9, 30), "end": (1, 7, 10, 30), "priority": 4, "text": "Agentic AI 실습"},
-        {"title": "생성형 AI 유즈 케이스 기반 실습 2", "category": "activity", "start": (1, 7, 10, 30), "end": (1, 7, 11, 30), "priority": 4},
-        {"title": "AI Agent 개념 및 플랫폼 소개", "category": "activity", "start": (1, 7, 13, 0), "end": (1, 7, 13, 50), "priority": 4},
-        {"title": "AI Agent 유즈 케이스 기반 실습 1", "category": "activity", "start": (1, 7, 13, 50), "end": (1, 7, 14, 40), "priority": 4},
-        {"title": "AI Agent 유즈 케이스 기반 실습 2", "category": "activity", "start": (1, 7, 15, 0), "end": (1, 7, 15, 50), "priority": 4},
-        {"title": "AI Agent Orchestration 활용 사례 데모", "category": "activity", "start": (1, 7, 16, 0), "end": (1, 7, 17, 0), "priority": 4},
-        {"title": "조별과제 논의", "category": "team", "start": (1, 7, 17, 0), "end": (1, 7, 17, 30), "priority": 3},
+        {"title": "생성형 AI 유즈 케이스 기반 실습 1", "category": "activity", "start": (1, 7, 9, 30), "end": (1, 7, 10, 30), "priority": 4, "text": "Agentic AI 실습", "color": "#4ECDC4"},
+        {"title": "생성형 AI 유즈 케이스 기반 실습 2", "category": "activity", "start": (1, 7, 10, 30), "end": (1, 7, 11, 30), "priority": 4, "color": "#4ECDC4"},
+        {"title": "AI Agent 개념 및 플랫폼 소개", "category": "activity", "start": (1, 7, 13, 0), "end": (1, 7, 13, 50), "priority": 4, "color": "#4ECDC4"},
+        {"title": "AI Agent 유즈 케이스 기반 실습 1", "category": "activity", "start": (1, 7, 13, 50), "end": (1, 7, 14, 40), "priority": 4, "color": "#4ECDC4"},
+        {"title": "AI Agent 유즈 케이스 기반 실습 2", "category": "activity", "start": (1, 7, 15, 0), "end": (1, 7, 15, 50), "priority": 4, "color": "#4ECDC4"},
+        {"title": "AI Agent Orchestration 활용 사례 데모", "category": "activity", "start": (1, 7, 16, 0), "end": (1, 7, 17, 0), "priority": 4, "color": "#4ECDC4"},
+        {"title": "조별과제 논의", "category": "team", "start": (1, 7, 17, 0), "end": (1, 7, 17, 30), "priority": 3, "color": "#7ED957"},
         
         # Day 4 (1/8 목) - Project 준비
-        {"title": "IBM Client Zero 및 watsonx Challenge 사례 소개", "category": "activity", "start": (1, 8, 9, 30), "end": (1, 8, 10, 30), "priority": 4, "text": "Project 준비"},
-        {"title": "watsonx Code Assistant 소개 및 활용 데모", "category": "activity", "start": (1, 8, 10, 30), "end": (1, 8, 11, 30), "priority": 4},
-        {"title": "멘토링 및 프로젝트 절차 소개", "category": "activity", "start": (1, 8, 13, 0), "end": (1, 8, 13, 50), "priority": 4},
-        {"title": "Design Thinking Workshop", "category": "activity", "start": (1, 8, 13, 50), "end": (1, 8, 14, 40), "priority": 4},
-        {"title": "조별 주제 선정", "category": "team", "start": (1, 8, 15, 0), "end": (1, 8, 17, 0), "priority": 5},
-        {"title": "조별 과제 준비", "category": "team", "start": (1, 8, 17, 0), "end": (1, 8, 17, 30), "priority": 4},
+        {"title": "IBM Client Zero 및 watsonx Challenge 사례 소개", "category": "activity", "start": (1, 8, 9, 30), "end": (1, 8, 10, 30), "priority": 4, "text": "Project 준비", "color": "#FFB347"},
+        {"title": "watsonx Code Assistant 소개 및 활용 데모", "category": "activity", "start": (1, 8, 10, 30), "end": (1, 8, 11, 30), "priority": 4, "color": "#FFB347"},
+        {"title": "멘토링 및 프로젝트 절차 소개", "category": "activity", "start": (1, 8, 13, 0), "end": (1, 8, 13, 50), "priority": 4, "color": "#FFB347"},
+        {"title": "Design Thinking Workshop", "category": "activity", "start": (1, 8, 13, 50), "end": (1, 8, 14, 40), "priority": 4, "color": "#FFB347"},
+        {"title": "조별 주제 선정", "category": "team", "start": (1, 8, 15, 0), "end": (1, 8, 17, 0), "priority": 5, "color": "#7ED957"},
+        {"title": "조별 과제 준비", "category": "team", "start": (1, 8, 17, 0), "end": (1, 8, 17, 30), "priority": 4, "color": "#7ED957"},
         
         # Day 5-9 (1/9~14) - Project & Mentoring
-        {"title": "해커톤 프로젝트 수행", "category": "team", "start": (1, 9, 9, 0), "end": (1, 14, 18, 0), "priority": 5, "type": "task", "text": "Project & Mentoring 기간"},
-        {"title": "멘토링 세션", "category": "activity", "start": (1, 9, 17, 0), "end": (1, 9, 17, 30), "priority": 4},
+        {"title": "해커톤 프로젝트 수행", "category": "team", "start": (1, 9, 9, 0), "end": (1, 14, 18, 0), "priority": 5, "type": "task", "text": "Project & Mentoring 기간", "color": "#FF6B6B"},
+        {"title": "멘토링 세션", "category": "activity", "start": (1, 9, 17, 0), "end": (1, 9, 17, 30), "priority": 4, "color": "#FF8ED4"},
         
         # Day 10 (1/15 목) - Project 발표
-        {"title": "현직자와 질의 응답 1", "category": "activity", "start": (1, 15, 9, 30), "end": (1, 15, 10, 30), "priority": 4, "text": "Project 발표"},
-        {"title": "현직자와 질의 응답 2", "category": "activity", "start": (1, 15, 10, 30), "end": (1, 15, 11, 30), "priority": 4},
-        {"title": "해커톤 결과 발표", "category": "activity", "start": (1, 15, 13, 50), "end": (1, 15, 14, 40), "priority": 5},
+        {"title": "현직자와 질의 응답 1", "category": "activity", "start": (1, 15, 9, 30), "end": (1, 15, 10, 30), "priority": 4, "text": "Project 발표", "color": "#FF8ED4"},
+        {"title": "현직자와 질의 응답 2", "category": "activity", "start": (1, 15, 10, 30), "end": (1, 15, 11, 30), "priority": 4, "color": "#FF8ED4"},
+        {"title": "해커톤 결과 발표", "category": "activity", "start": (1, 15, 13, 50), "end": (1, 15, 14, 40), "priority": 5, "color": "#FF6B6B"},
         
         # Day 11 (1/16 금) - 최종 발표 및 시상
-        {"title": "해커톤 최종 발표", "category": "activity", "start": (1, 16, 15, 0), "end": (1, 16, 17, 0), "priority": 5, "text": "최종 발표"},
-        {"title": "🏆 시상 및 종료", "category": "activity", "start": (1, 16, 17, 0), "end": (1, 16, 17, 30), "priority": 5, "text": "강릉원주대 x 강원대학교 AI 개발자 해커톤 종료"},
+        {"title": "해커톤 최종 발표", "category": "activity", "start": (1, 16, 15, 0), "end": (1, 16, 17, 0), "priority": 5, "text": "최종 발표", "color": "#FF6B6B"},
+        {"title": "🏆 시상 및 종료", "category": "activity", "start": (1, 16, 17, 0), "end": (1, 16, 17, 30), "priority": 5, "text": "강릉원주대 x 강원대학교 AI 개발자 해커톤 종료", "color": "#FFE066"},
     ]
     
     # ========================================
@@ -91,45 +91,45 @@ def get_seed_schedules():
     # ========================================
     kangwon_schedules = [
         # 2월
-        {"title": "제1차 정시모집 합격자 발표", "category": "other", "start": (2, 6, 10, 0), "end": (2, 6, 18, 0), "priority": 3},
-        {"title": "제1차 정시모집 등록", "category": "other", "start": (2, 10, 9, 0), "end": (2, 12, 16, 0), "priority": 3},
-        {"title": "제2차 정시모집 합격자 발표", "category": "other", "start": (2, 16, 10, 0), "end": (2, 16, 18, 0), "priority": 3},
-        {"title": "제2차 정시모집 등록", "category": "other", "start": (2, 19, 9, 0), "end": (2, 20, 16, 0), "priority": 3},
-        {"title": "추가모집 합격자 발표", "category": "other", "start": (2, 25, 10, 0), "end": (2, 25, 18, 0), "priority": 3},
-        {"title": "추가모집 등록", "category": "other", "start": (2, 26, 9, 0), "end": (2, 27, 16, 0), "priority": 3},
-        {"title": "학위수여식", "category": "activity", "start": (2, 20, 11, 0), "end": (2, 20, 12, 0), "priority": 4},
+        {"title": "제1차 정시모집 합격자 발표", "category": "other", "start": (2, 6, 10, 0), "end": (2, 6, 18, 0), "priority": 3, "color": "#A0A0A0"},
+        {"title": "제1차 정시모집 등록", "category": "other", "start": (2, 10, 9, 0), "end": (2, 12, 16, 0), "priority": 3, "color": "#A0A0A0"},
+        {"title": "제2차 정시모집 합격자 발표", "category": "other", "start": (2, 16, 10, 0), "end": (2, 16, 18, 0), "priority": 3, "color": "#A0A0A0"},
+        {"title": "제2차 정시모집 등록", "category": "other", "start": (2, 19, 9, 0), "end": (2, 20, 16, 0), "priority": 3, "color": "#A0A0A0"},
+        {"title": "추가모집 합격자 발표", "category": "other", "start": (2, 25, 10, 0), "end": (2, 25, 18, 0), "priority": 3, "color": "#A0A0A0"},
+        {"title": "추가모집 등록", "category": "other", "start": (2, 26, 9, 0), "end": (2, 27, 16, 0), "priority": 3, "color": "#A0A0A0"},
+        {"title": "학위수여식", "category": "activity", "start": (2, 20, 11, 0), "end": (2, 20, 12, 0), "priority": 4, "color": "#FFE066"},
         
         # 3월
-        {"title": "1학기 개강", "category": "class", "start": (3, 2, 9, 0), "end": (3, 2, 18, 0), "priority": 5, "text": "2026학년도 1학기 시작"},
-        {"title": "수강신청 정정기간", "category": "class", "start": (3, 2, 9, 0), "end": (3, 6, 17, 0), "priority": 4, "type": "task"},
-        {"title": "1학기 등록금 납부기간", "category": "other", "start": (3, 2, 9, 0), "end": (3, 13, 16, 0), "priority": 4},
-        {"title": "삼일절 (휴일)", "category": "other", "start": (3, 1, 0, 0), "end": (3, 1, 23, 59), "priority": 2},
-        {"title": "수강철회 기간", "category": "class", "start": (3, 23, 9, 0), "end": (3, 27, 17, 0), "priority": 3, "type": "task"},
+        {"title": "1학기 개강", "category": "class", "start": (3, 2, 9, 0), "end": (3, 2, 18, 0), "priority": 5, "text": "2026학년도 1학기 시작", "color": "#4F8CFF"},
+        {"title": "수강신청 정정기간", "category": "class", "start": (3, 2, 9, 0), "end": (3, 6, 17, 0), "priority": 4, "type": "task", "color": "#9B7EFF"},
+        {"title": "1학기 등록금 납부기간", "category": "other", "start": (3, 2, 9, 0), "end": (3, 13, 16, 0), "priority": 4, "color": "#FFB347"},
+        {"title": "삼일절 (휴일)", "category": "other", "start": (3, 1, 0, 0), "end": (3, 1, 23, 59), "priority": 2, "color": "#FF6B6B"},
+        {"title": "수강철회 기간", "category": "class", "start": (3, 23, 9, 0), "end": (3, 27, 17, 0), "priority": 3, "type": "task", "color": "#9B7EFF"},
         
         # 4월
-        {"title": "중간고사 기간", "category": "exam", "start": (4, 20, 9, 0), "end": (4, 24, 18, 0), "priority": 5, "type": "task", "text": "1학기 중간고사"},
+        {"title": "중간고사 기간", "category": "exam", "start": (4, 20, 9, 0), "end": (4, 24, 18, 0), "priority": 5, "type": "task", "text": "1학기 중간고사", "color": "#FF6B6B"},
         
         # 5월
-        {"title": "어린이날 (휴일)", "category": "other", "start": (5, 5, 0, 0), "end": (5, 5, 23, 59), "priority": 2},
-        {"title": "석가탄신일 (휴일)", "category": "other", "start": (5, 24, 0, 0), "end": (5, 24, 23, 59), "priority": 2},
-        {"title": "대동제 (축제)", "category": "activity", "start": (5, 13, 18, 0), "end": (5, 15, 22, 0), "priority": 4, "text": "강원대학교 대동제"},
+        {"title": "어린이날 (휴일)", "category": "other", "start": (5, 5, 0, 0), "end": (5, 5, 23, 59), "priority": 2, "color": "#7ED957"},
+        {"title": "석가탄신일 (휴일)", "category": "other", "start": (5, 24, 0, 0), "end": (5, 24, 23, 59), "priority": 2, "color": "#7ED957"},
+        {"title": "대동제 (축제)", "category": "activity", "start": (5, 13, 18, 0), "end": (5, 15, 22, 0), "priority": 4, "text": "강원대학교 대동제", "color": "#FF8ED4"},
         
         # 6월
-        {"title": "현충일 (휴일)", "category": "other", "start": (6, 6, 0, 0), "end": (6, 6, 23, 59), "priority": 2},
-        {"title": "기말고사 기간", "category": "exam", "start": (6, 15, 9, 0), "end": (6, 19, 18, 0), "priority": 5, "type": "task", "text": "1학기 기말고사"},
-        {"title": "1학기 종강", "category": "class", "start": (6, 19, 9, 0), "end": (6, 19, 18, 0), "priority": 4},
-        {"title": "1학기 성적입력 기간", "category": "class", "start": (6, 22, 9, 0), "end": (6, 26, 17, 0), "priority": 3},
-        {"title": "1학기 성적열람 및 이의신청", "category": "class", "start": (6, 29, 9, 0), "end": (7, 1, 17, 0), "priority": 3, "type": "task"},
+        {"title": "현충일 (휴일)", "category": "other", "start": (6, 6, 0, 0), "end": (6, 6, 23, 59), "priority": 2, "color": "#A0A0A0"},
+        {"title": "기말고사 기간", "category": "exam", "start": (6, 15, 9, 0), "end": (6, 19, 18, 0), "priority": 5, "type": "task", "text": "1학기 기말고사", "color": "#FF6B6B"},
+        {"title": "1학기 종강", "category": "class", "start": (6, 19, 9, 0), "end": (6, 19, 18, 0), "priority": 4, "color": "#4F8CFF"},
+        {"title": "1학기 성적입력 기간", "category": "class", "start": (6, 22, 9, 0), "end": (6, 26, 17, 0), "priority": 3, "color": "#9B7EFF"},
+        {"title": "1학기 성적열람 및 이의신청", "category": "class", "start": (6, 29, 9, 0), "end": (7, 1, 17, 0), "priority": 3, "type": "task", "color": "#9B7EFF"},
         
         # 7월
-        {"title": "여름방학 시작", "category": "other", "start": (7, 1, 0, 0), "end": (7, 1, 23, 59), "priority": 3, "text": "여름방학"},
-        {"title": "계절학기 수강신청", "category": "class", "start": (7, 6, 9, 0), "end": (7, 8, 17, 0), "priority": 3},
-        {"title": "하계 계절학기", "category": "class", "start": (7, 13, 9, 0), "end": (8, 7, 18, 0), "priority": 3, "type": "task"},
+        {"title": "여름방학 시작", "category": "other", "start": (7, 1, 0, 0), "end": (7, 1, 23, 59), "priority": 3, "text": "여름방학", "color": "#4ECDC4"},
+        {"title": "계절학기 수강신청", "category": "class", "start": (7, 6, 9, 0), "end": (7, 8, 17, 0), "priority": 3, "color": "#9B7EFF"},
+        {"title": "하계 계절학기", "category": "class", "start": (7, 13, 9, 0), "end": (8, 7, 18, 0), "priority": 3, "type": "task", "color": "#4ECDC4"},
         
         # 8월
-        {"title": "2학기 수강신청", "category": "class", "start": (8, 17, 9, 0), "end": (8, 21, 17, 0), "priority": 4, "type": "task", "text": "2학기 수강신청 기간"},
-        {"title": "광복절 (휴일)", "category": "other", "start": (8, 15, 0, 0), "end": (8, 15, 23, 59), "priority": 2},
-        {"title": "2학기 개강", "category": "class", "start": (8, 31, 9, 0), "end": (8, 31, 18, 0), "priority": 5, "text": "2026학년도 2학기 시작"},
+        {"title": "2학기 수강신청", "category": "class", "start": (8, 17, 9, 0), "end": (8, 21, 17, 0), "priority": 4, "type": "task", "text": "2학기 수강신청 기간", "color": "#9B7EFF"},
+        {"title": "광복절 (휴일)", "category": "other", "start": (8, 15, 0, 0), "end": (8, 15, 23, 59), "priority": 2, "color": "#FF6B6B"},
+        {"title": "2학기 개강", "category": "class", "start": (8, 31, 9, 0), "end": (8, 31, 18, 0), "priority": 5, "text": "2026학년도 2학기 시작", "color": "#4F8CFF"},
     ]
     
     # 일정 데이터 변환
@@ -150,6 +150,7 @@ def get_seed_schedules():
             "priority_score": item["priority"],
             "original_text": item.get("text"),
             "source": "manual",
+            "color": item.get("color"),
         }
         schedules.append(schedule)
     

--- a/backend/app/models/schedule.py
+++ b/backend/app/models/schedule.py
@@ -15,6 +15,7 @@ class Schedule(Base):
     type = Column(String(255), nullable=True)   # task (AI로 Sub task가 생성되는 것), evnet (그 외)
     title = Column(String(255), nullable=False)
     category = Column(String(50), nullable=True)    # class, assignment, exam, team, activity, other
+    color = Column(String(20), nullable=True)       # 일정 색상 (hex 코드)
     start_at = Column(DateTime, nullable=True)
     end_at = Column(DateTime, nullable=False)
     priority_score = Column(Integer, default=1, nullable=False)     

--- a/backend/app/schemas/schedule.py
+++ b/backend/app/schemas/schedule.py
@@ -8,6 +8,7 @@ class SaveScheduleRequest(BaseModel):
     title: str = Field(..., example="캡스톤 디자인 최종 발표")
     type: Optional[str] = Field("task", example="task")
     category: Optional[str] = Field("assignment", example="assignment")
+    color: Optional[str] = Field(None, example="#4F8CFF")
     start_at: Optional[datetime] = Field(None, example="2026-06-20T00:00:00")
     end_at: datetime = Field(..., example="2026-06-20T23:59:59")
     priority_score: int = Field(1, ge=0, le=10, example=8)
@@ -22,6 +23,7 @@ class ScheduleResponse(BaseModel):
     title: str
     type: Optional[str]
     category: Optional[str]
+    color: Optional[str]
     start_at: Optional[datetime]
     end_at: datetime
     priority_score: int
@@ -44,6 +46,7 @@ class UpdateScheduleRequest(BaseModel):
     title: Optional[str] = Field(None, example="캡스톤 디자인 최종 발표")
     type: Optional[str] = Field(None, example="task")
     category: Optional[str] = Field(None, example="assignment")
+    color: Optional[str] = Field(None, example="#4F8CFF")
     start_at: Optional[datetime] = Field(None, example="2026-06-21T00:00:00")
     end_at: Optional[datetime] = Field(None, example="2026-06-21T23:59:59")
     priority_score: Optional[int] = Field(None, ge=0, le=10, example=2)

--- a/backend/app/schemas/sub_task.py
+++ b/backend/app/schemas/sub_task.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 import datetime
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict, Any
 
 
 # 할 일 저장 요청 스키마
@@ -37,6 +37,7 @@ class SubTaskResponse(BaseModel):
     priority: Optional[str] = None
     category: Optional[str] = None
     tip: Optional[str] = None
+    schedule: Optional[Dict[str, Any]] = None  # 일정 정보 (색상 등)
 
     class Config:
         from_attributes = True

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import Header from './components/layout/Header';
+import ChatbotButton from './components/chatbot/ChatbotButton';
+import ChatbotWindow from './components/chatbot/ChatbotWindow';
+import { useChatbot } from './hooks/useChatbot';
+import { useAuth } from './context/AuthContext';
 import Home from './pages/Home';
 import FullCalendar from './pages/FullCalendar';
 import TaskDetail from './pages/TaskDetail';
@@ -45,6 +49,54 @@ const requestNotificationPermission = async () => {
   }
 
   return false;
+};
+
+// 챗봇을 전역으로 렌더링하는 컴포넌트 (로그인/회원가입 페이지 제외)
+const GlobalChatbot = () => {
+  const location = useLocation();
+  const { requireAuth } = useAuth();
+  const {
+    isOpen: isChatOpen,
+    messages,
+    loading: chatLoading,
+    messagesEndRef,
+    toggleChatbot,
+    sendMessage,
+    confirmAction,
+    cancelAction,
+    clearMessages,
+    retryLastMessage,
+    lastUserMessage,
+    selectScheduleForNotification,
+    handleChoiceSelect,
+  } = useChatbot();
+
+  // 로그인/회원가입 페이지에서는 챗봇 숨김
+  const hiddenPaths = ['/login', '/signup'];
+  if (hiddenPaths.includes(location.pathname)) {
+    return null;
+  }
+
+  return (
+    <>
+      <ChatbotButton onClick={() => requireAuth(() => toggleChatbot())} />
+      <ChatbotWindow
+        isOpen={isChatOpen}
+        onClose={toggleChatbot}
+        messages={messages}
+        onSendMessage={sendMessage}
+        loading={chatLoading}
+        messagesEndRef={messagesEndRef}
+        onConfirmAction={confirmAction}
+        onCancelAction={cancelAction}
+        onClearHistory={clearMessages}
+        onRetry={retryLastMessage}
+        canRetry={!!lastUserMessage}
+        onSelectScheduleForNotification={selectScheduleForNotification}
+        onChoiceSelect={handleChoiceSelect}
+      />
+    </>
+  );
 };
 
 function App() {
@@ -101,6 +153,7 @@ function App() {
           <BrowserRouter>
             <NetworkStatus />
             <LoginModal />
+            <GlobalChatbot />
             <div className="app">
               <Routes>
                 {/* 인증 페이지 (헤더 없음) */}

--- a/frontend/src/components/calendar/Calendar.css
+++ b/frontend/src/components/calendar/Calendar.css
@@ -452,10 +452,12 @@
 .schedule-modal__select {
   cursor: pointer;
   appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%234e5968' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%234e5968' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 12px center;
-  padding-right: 40px;
+  padding-right: 36px;
 }
 
 .schedule-modal__select--category {

--- a/frontend/src/components/calendar/Calendar.css
+++ b/frontend/src/components/calendar/Calendar.css
@@ -594,7 +594,43 @@
   box-shadow: 0 0 0 3px #f0f6ff;
 }
 
+/* 색상 선택기 */
+.schedule-modal__color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.schedule-modal__color-option {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.schedule-modal__color-option:hover {
+  transform: scale(1.1);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.schedule-modal__color-option--selected {
+  border-color: #191f28;
+  transform: scale(1.1);
+}
+
 /* 메모 영역 */
+.schedule-modal__field--memo {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #f2f4f6;
+}
+
 .schedule-modal__memo-header {
   display: flex;
   align-items: center;

--- a/frontend/src/components/calendar/Calendar.jsx
+++ b/frontend/src/components/calendar/Calendar.jsx
@@ -19,6 +19,7 @@ const Calendar = ({ onDateSelect, isFullMode = false }) => {
     currentDate,
     selectedDate,
     dates,
+    events,
     loading,
     goToPreviousMonth,
     goToNextMonth,
@@ -104,6 +105,7 @@ const Calendar = ({ onDateSelect, isFullMode = false }) => {
         isFullMode={isFullMode}
         getEventsForDate={getEventsForDate}
         getTodosForDate={getTodosForDate}
+        allEvents={events}
       />
 
       {/* 연월 선택 모달 */}

--- a/frontend/src/components/calendar/Calendar.jsx
+++ b/frontend/src/components/calendar/Calendar.jsx
@@ -246,24 +246,12 @@ const MonthPicker = ({ currentDate, onSelect, onClose }) => {
 
 // 일정 편집 모달 컴포넌트 (갤럭시 캘린더 스타일)
 const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleClick, refetch }) => {
-  // 일정별 색상 팔레트
-  const eventColors = [
-    '#3b82f6', // 파랑
-    '#10b981', // 초록
-    '#f59e0b', // 주황
-    '#ef4444', // 빨강
-    '#8b5cf6', // 보라
-    '#ec4899', // 핑크
-    '#06b6d4', // 시안
-    '#f97316', // 오렌지
-  ];
+  // 기본 색상 (일정에 색상이 설정되지 않은 경우)
+  const DEFAULT_EVENT_COLOR = '#4F8CFF';
 
-  // 일정 ID를 기반으로 색상 선택
-  const getEventColor = (eventId, index) => {
-    if (!eventId) return eventColors[index % eventColors.length];
-    // ID를 숫자로 변환하여 색상 선택
-    const hash = eventId.toString().split('').reduce((acc, char) => acc + char.charCodeAt(0), 0);
-    return eventColors[hash % eventColors.length];
+  // 일정 색상 가져오기 - event.color가 있으면 사용, 없으면 기본 파란색
+  const getEventColor = (event) => {
+    return event?.color || DEFAULT_EVENT_COLOR;
   };
 
   // start_at/end_at에서 시간 추출 함수
@@ -515,7 +503,7 @@ const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleCli
                     >
                       <div 
                         className="schedule-modal__event-indicator" 
-                        style={{ backgroundColor: getEventColor(event.id, index) }}
+                        style={{ backgroundColor: getEventColor(event) }}
                       />
                       <div className="schedule-modal__event-content">
                         <span className="schedule-modal__event-title">{event.title}</span>

--- a/frontend/src/components/calendar/Calendar.jsx
+++ b/frontend/src/components/calendar/Calendar.jsx
@@ -335,6 +335,22 @@ const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleCli
   const [category, setCategory] = useState('');
   const [priorityScore, setPriorityScore] = useState(5);
   const [estimatedMinute, setEstimatedMinute] = useState('');
+  const [color, setColor] = useState('');
+
+  // 일정 색상 옵션 (부드러운 파스텔톤 10가지)
+  const COLOR_OPTIONS = [
+    { value: '', label: '기본', color: '#4F8CFF' },
+    { value: '#FF6B6B', label: '코랄', color: '#FF6B6B' },
+    { value: '#FFB347', label: '오렌지', color: '#FFB347' },
+    { value: '#FFE066', label: '옐로우', color: '#FFE066' },
+    { value: '#7ED957', label: '그린', color: '#7ED957' },
+    { value: '#4ECDC4', label: '민트', color: '#4ECDC4' },
+    { value: '#4F8CFF', label: '블루', color: '#4F8CFF' },
+    { value: '#9B7EFF', label: '퍼플', color: '#9B7EFF' },
+    { value: '#FF8ED4', label: '핑크', color: '#FF8ED4' },
+    { value: '#A0A0A0', label: '그레이', color: '#A0A0A0' },
+    { value: '#8B6F47', label: '브라운', color: '#8B6F47' },
+  ];
 
   // initialEvents가 변경되면 localEvents 업데이트
   useEffect(() => {
@@ -363,6 +379,7 @@ const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleCli
     setCategory('');
     setPriorityScore(5);
     setEstimatedMinute('');
+    setColor('');
     setShowForm(true);
   };
 
@@ -386,6 +403,7 @@ const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleCli
       isAllDay,
       type: 'schedule',
       category: category.trim(),
+      color: color || null,
       priority_score: parseInt(priorityScore) || 5,
       estimated_minute: estimatedMinute ? parseInt(estimatedMinute) : null,
     };
@@ -415,6 +433,7 @@ const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleCli
           endTime: scheduleData.endTime,
           isAllDay: scheduleData.isAllDay,
           description: savedEvent.original_text || scheduleData.description,
+          color: savedEvent.color || scheduleData.color,
         };
         
         setLocalEvents(prev => [...prev, newEvent]);
@@ -428,6 +447,7 @@ const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleCli
       setCategory('');
       setPriorityScore(5);
       setEstimatedMinute('');
+      setColor('');
     } catch (error) {
       console.error('일정 저장 실패:', error);
       alert('일정 저장에 실패했습니다. 다시 시도해주세요.');
@@ -568,6 +588,29 @@ const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleCli
               </select>
             </div>
 
+            {/* 색상 선택 */}
+            <div className="schedule-modal__field">
+              <label className="schedule-modal__label">색상</label>
+              <div className="schedule-modal__color-picker">
+                {COLOR_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={`schedule-modal__color-option ${color === option.value ? 'schedule-modal__color-option--selected' : ''}`}
+                    style={{ backgroundColor: option.color }}
+                    onClick={() => setColor(option.value)}
+                    title={option.label}
+                  >
+                    {color === option.value && (
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+
             {/* 우선순위 */}
             <div className="schedule-modal__field">
               <label className="schedule-modal__label">우선순위 (1-10)</label>
@@ -666,7 +709,7 @@ const ScheduleEditModal = ({ date, events: initialEvents, onClose, onScheduleCli
             </div>
 
             {/* 메모 */}
-            <div className="schedule-modal__field">
+            <div className="schedule-modal__field schedule-modal__field--memo">
               <div className="schedule-modal__memo-header">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />

--- a/frontend/src/components/calendar/CalendarGrid.css
+++ b/frontend/src/components/calendar/CalendarGrid.css
@@ -67,6 +67,7 @@
 .calendar-grid__week {
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .calendar-grid--full-mode .calendar-grid__week {
@@ -91,49 +92,70 @@
   gap: 2px;
 }
 
-/* 멀티데이 이벤트 바 영역 */
-.calendar-grid__multiday-events {
+/* 멀티데이 이벤트 바 영역 - absolute 레이어 */
+.calendar-grid__multiday-layer {
+  position: absolute;
+  top: 28px;
+  left: 0;
+  right: 0;
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 2px 0;
-  padding: 2px 0;
-  min-height: 22px;
+  grid-auto-rows: 20px;
+  gap: 0;
+  pointer-events: none;
+  z-index: 2;
 }
 
 .calendar-grid__multiday-bar {
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 8px;
-  font-size: 11px;
-  font-weight: 500;
+  padding: 3px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
   color: white;
   background-color: var(--color-primary-500);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
+  pointer-events: auto;
   transition: filter 0.2s;
-  margin: 0 -1px;
-  z-index: 1;
+  margin: 1px 4px;
+  height: 18px;
 }
 
 .calendar-grid__multiday-bar:hover {
   filter: brightness(1.1);
 }
 
-/* 시작 부분 - 왼쪽 둥글게 */
-.calendar-grid__multiday-bar--start {
-  border-top-left-radius: 4px;
-  border-bottom-left-radius: 4px;
-  margin-left: 2px;
+/* 중간 부분 - 둥글기 없음 */
+.calendar-grid__multiday-bar:not(.calendar-grid__multiday-bar--start):not(.calendar-grid__multiday-bar--end) {
+  border-radius: 0;
 }
 
-/* 끝 부분 - 오른쪽 둥글게 */
+/* 시작 부분 - 왼쪽만 둥글게 */
+.calendar-grid__multiday-bar--start {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-left: 4px;
+}
+
+/* 끝 부분 - 오른쪽만 둥글게 */
 .calendar-grid__multiday-bar--end {
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-  margin-right: 2px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-right: 4px;
+}
+
+/* 시작이면서 끝인 경우 (한 주 안에 끝남) - 양쪽 둥글게 */
+.calendar-grid__multiday-bar--start.calendar-grid__multiday-bar--end {
+  border-radius: 3px;
 }
 
 .multiday-bar__google-icon {
@@ -149,6 +171,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding: 0 4px;
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/components/calendar/CalendarGrid.css
+++ b/frontend/src/components/calendar/CalendarGrid.css
@@ -51,10 +51,104 @@
   color: var(--color-primary-500);
 }
 
+/* 주별 컨테이너 */
+.calendar-grid__weeks {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.calendar-grid--full-mode .calendar-grid__weeks {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-grid__week {
+  display: flex;
+  flex-direction: column;
+}
+
+.calendar-grid--full-mode .calendar-grid__week {
+  flex: 1;
+  min-height: 0;
+}
+
+.calendar-grid__dates-row {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.calendar-grid--full-mode .calendar-grid__dates-row {
+  flex: 1;
+  min-height: 0;
+}
+
 .calendar-grid__dates {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
   gap: 2px;
+}
+
+/* 멀티데이 이벤트 바 영역 */
+.calendar-grid__multiday-events {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px 0;
+  padding: 2px 0;
+  min-height: 22px;
+}
+
+.calendar-grid__multiday-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: white;
+  background-color: var(--color-primary-500);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: filter 0.2s;
+  margin: 0 -1px;
+  z-index: 1;
+}
+
+.calendar-grid__multiday-bar:hover {
+  filter: brightness(1.1);
+}
+
+/* 시작 부분 - 왼쪽 둥글게 */
+.calendar-grid__multiday-bar--start {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+  margin-left: 2px;
+}
+
+/* 끝 부분 - 오른쪽 둥글게 */
+.calendar-grid__multiday-bar--end {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+  margin-right: 2px;
+}
+
+.multiday-bar__google-icon {
+  font-size: 9px;
+  font-weight: 700;
+  background: rgba(255, 255, 255, 0.3);
+  padding: 1px 3px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.multiday-bar__title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (max-width: 640px) {
@@ -67,7 +161,17 @@
     padding: var(--spacing-xs);
   }
 
-  .calendar-grid__dates {
+  .calendar-grid__dates,
+  .calendar-grid__dates-row {
     gap: 2px;
+  }
+
+  .calendar-grid__multiday-events {
+    min-height: 18px;
+  }
+
+  .calendar-grid__multiday-bar {
+    font-size: 10px;
+    padding: 1px 4px;
   }
 }

--- a/frontend/src/components/calendar/CalendarGrid.jsx
+++ b/frontend/src/components/calendar/CalendarGrid.jsx
@@ -55,7 +55,7 @@ const getMultiDayEventsForWeek = (weekDates, events) => {
   return multiDayEvents;
 };
 
-// 카테고리별 색상 매핑
+// 카테고리별 색상 매핑 (일정 색상이 없을 때 기본값)
 const getCategoryColor = (category) => {
   const colors = {
     assignment: '#3b82f6',
@@ -66,6 +66,13 @@ const getCategoryColor = (category) => {
     other: '#6b7280',
   };
   return colors[category] || colors.other;
+};
+
+// 이벤트 색상 가져오기 (event.color 우선, 없으면 카테고리 색상)
+const getEventColor = (event) => {
+  if (event.source === 'google') return '#ea4335';
+  if (event.color) return event.color;
+  return getCategoryColor(event.category);
 };
 
 const CalendarGrid = ({ dates, selectedDate, onDateClick, onDateDoubleClick, hasEventsOnDate, hasCompletedOnDate, hasPendingOnDate, hasGoogleEventsOnDate = () => false, isFullMode = false, getEventsForDate, getTodosForDate, allEvents = [] }) => {
@@ -132,7 +139,7 @@ const CalendarGrid = ({ dates, selectedDate, onDateClick, onDateDoubleClick, has
                     className={`calendar-grid__multiday-bar ${event.isStart ? 'calendar-grid__multiday-bar--start' : ''} ${event.isEnd ? 'calendar-grid__multiday-bar--end' : ''}`}
                     style={{
                       gridColumn: `${event.startCol + 1} / span ${event.span}`,
-                      backgroundColor: event.source === 'google' ? '#ea4335' : getCategoryColor(event.category),
+                      backgroundColor: getEventColor(event),
                     }}
                     title={`${event.title} (${formatDate(new Date(event.start_at || event.startDate), 'MM/DD')} ~ ${formatDate(new Date(event.end_at || event.endDate), 'MM/DD')})`}
                   >

--- a/frontend/src/components/calendar/CalendarGrid.jsx
+++ b/frontend/src/components/calendar/CalendarGrid.jsx
@@ -1,10 +1,109 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import DateCell from './DateCell';
 import { WEEKDAYS } from '../../utils/constants';
-import { isSameDay } from '../../utils/dateUtils';
+import { isSameDay, formatDate } from '../../utils/dateUtils';
 import './CalendarGrid.css';
 
-const CalendarGrid = ({ dates, selectedDate, onDateClick, onDateDoubleClick, hasEventsOnDate, hasCompletedOnDate, hasPendingOnDate, hasGoogleEventsOnDate = () => false, isFullMode = false, getEventsForDate, getTodosForDate }) => {
+// 멀티데이 이벤트를 주별로 분할하는 함수
+const getMultiDayEventsForWeek = (weekDates, events) => {
+  const multiDayEvents = [];
+  
+  events.forEach(event => {
+    const startDate = new Date(event.start_at || event.startDate || event.date);
+    const endDate = new Date(event.end_at || event.endDate || event.date);
+    
+    // 시작일과 마감일이 다른 경우만 멀티데이 이벤트로 처리
+    if (startDate.toDateString() === endDate.toDateString()) return;
+    
+    const weekStart = weekDates[0].date;
+    const weekEnd = weekDates[6].date;
+    
+    // 이벤트가 이번 주와 겹치는지 확인
+    if (endDate < weekStart || startDate > weekEnd) return;
+    
+    // 이번 주에서 이벤트가 차지하는 범위 계산
+    let startCol = 0;
+    let endCol = 6;
+    
+    for (let i = 0; i < 7; i++) {
+      const cellDate = weekDates[i].date;
+      if (isSameDay(cellDate, startDate) || (startDate < cellDate && i === 0)) {
+        startCol = startDate < weekStart ? 0 : i;
+      }
+      if (isSameDay(cellDate, endDate) || (endDate > cellDate && i === 6)) {
+        endCol = endDate > weekEnd ? 6 : i;
+      }
+    }
+    
+    // 시작일이 이번 주 전인지 확인
+    const startsBeforeWeek = startDate < weekStart;
+    // 마감일이 이번 주 후인지 확인
+    const endsAfterWeek = endDate > weekEnd;
+    
+    multiDayEvents.push({
+      ...event,
+      startCol,
+      endCol,
+      span: endCol - startCol + 1,
+      isStart: !startsBeforeWeek && weekDates.some(d => isSameDay(d.date, startDate)),
+      isEnd: !endsAfterWeek && weekDates.some(d => isSameDay(d.date, endDate)),
+      isContinuation: startsBeforeWeek,
+      continuesNext: endsAfterWeek,
+    });
+  });
+  
+  return multiDayEvents;
+};
+
+// 카테고리별 색상 매핑
+const getCategoryColor = (category) => {
+  const colors = {
+    assignment: '#3b82f6',
+    exam: '#ef4444',
+    class: '#8b5cf6',
+    meeting: '#f59e0b',
+    personal: '#10b981',
+    other: '#6b7280',
+  };
+  return colors[category] || colors.other;
+};
+
+const CalendarGrid = ({ dates, selectedDate, onDateClick, onDateDoubleClick, hasEventsOnDate, hasCompletedOnDate, hasPendingOnDate, hasGoogleEventsOnDate = () => false, isFullMode = false, getEventsForDate, getTodosForDate, allEvents = [] }) => {
+  // 주별로 날짜 분할
+  const weeks = useMemo(() => {
+    const result = [];
+    for (let i = 0; i < dates.length; i += 7) {
+      result.push(dates.slice(i, i + 7));
+    }
+    return result;
+  }, [dates]);
+
+  // 각 주의 멀티데이 이벤트 계산
+  const multiDayEventsByWeek = useMemo(() => {
+    return weeks.map(weekDates => getMultiDayEventsForWeek(weekDates, allEvents));
+  }, [weeks, allEvents]);
+
+  // 단일 날짜 이벤트만 필터링 (멀티데이 제외)
+  const getSingleDayEventsForDate = (date) => {
+    if (!getEventsForDate) return [];
+    const events = getEventsForDate(date);
+    return events.filter(event => {
+      const startDate = new Date(event.start_at || event.startDate || event.date);
+      const endDate = new Date(event.end_at || event.endDate || event.date);
+      return startDate.toDateString() === endDate.toDateString();
+    });
+  };
+
+  // 해당 날짜에 멀티데이 이벤트가 있는지 확인
+  const hasMultiDayEventOnDate = (date) => {
+    return allEvents.some(event => {
+      const startDate = new Date(event.start_at || event.startDate || event.date);
+      const endDate = new Date(event.end_at || event.endDate || event.date);
+      if (startDate.toDateString() === endDate.toDateString()) return false;
+      return date >= startDate && date <= endDate;
+    });
+  };
+
   return (
     <div className={`calendar-grid ${isFullMode ? 'calendar-grid--full-mode' : ''}`}>
       {/* Weekday headers */}
@@ -20,24 +119,52 @@ const CalendarGrid = ({ dates, selectedDate, onDateClick, onDateDoubleClick, has
         ))}
       </div>
 
-      {/* Date cells */}
-      <div className="calendar-grid__dates">
-        {dates.map((dateObj, index) => (
-          <DateCell
-            key={index}
-            date={dateObj.date}
-            isCurrentMonth={dateObj.isCurrentMonth}
-            isSelected={isSameDay(dateObj.date, selectedDate)}
-            hasEvents={hasEventsOnDate(dateObj.date)}
-            hasCompleted={hasCompletedOnDate ? hasCompletedOnDate(dateObj.date) : false}
-            hasPending={hasPendingOnDate ? hasPendingOnDate(dateObj.date) : false}
-            hasGoogleEvents={hasGoogleEventsOnDate(dateObj.date)}
-            onClick={onDateClick}
-            onDoubleClick={onDateDoubleClick}
-            isFullMode={isFullMode}
-            events={getEventsForDate ? getEventsForDate(dateObj.date) : []}
-            todos={getTodosForDate ? getTodosForDate(dateObj.date) : []}
-          />
+      {/* Date cells with multi-day events */}
+      <div className="calendar-grid__weeks">
+        {weeks.map((weekDates, weekIndex) => (
+          <div key={weekIndex} className="calendar-grid__week">
+            {/* 멀티데이 이벤트 바 영역 */}
+            {isFullMode && multiDayEventsByWeek[weekIndex]?.length > 0 && (
+              <div className="calendar-grid__multiday-events">
+                {multiDayEventsByWeek[weekIndex].map((event, eventIndex) => (
+                  <div
+                    key={`${event.schedule_id || event.id}-${eventIndex}`}
+                    className={`calendar-grid__multiday-bar ${event.isStart ? 'calendar-grid__multiday-bar--start' : ''} ${event.isEnd ? 'calendar-grid__multiday-bar--end' : ''}`}
+                    style={{
+                      gridColumn: `${event.startCol + 1} / span ${event.span}`,
+                      backgroundColor: event.source === 'google' ? '#ea4335' : getCategoryColor(event.category),
+                    }}
+                    title={`${event.title} (${formatDate(new Date(event.start_at || event.startDate), 'MM/DD')} ~ ${formatDate(new Date(event.end_at || event.endDate), 'MM/DD')})`}
+                  >
+                    {event.source === 'google' && <span className="multiday-bar__google-icon">G</span>}
+                    <span className="multiday-bar__title">{event.title}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+            
+            {/* 날짜 셀들 */}
+            <div className="calendar-grid__dates-row">
+              {weekDates.map((dateObj, index) => (
+                <DateCell
+                  key={index}
+                  date={dateObj.date}
+                  isCurrentMonth={dateObj.isCurrentMonth}
+                  isSelected={isSameDay(dateObj.date, selectedDate)}
+                  hasEvents={hasEventsOnDate(dateObj.date)}
+                  hasMultiDayEvent={hasMultiDayEventOnDate(dateObj.date)}
+                  hasCompleted={hasCompletedOnDate ? hasCompletedOnDate(dateObj.date) : false}
+                  hasPending={hasPendingOnDate ? hasPendingOnDate(dateObj.date) : false}
+                  hasGoogleEvents={hasGoogleEventsOnDate(dateObj.date)}
+                  onClick={onDateClick}
+                  onDoubleClick={onDateDoubleClick}
+                  isFullMode={isFullMode}
+                  events={isFullMode ? getSingleDayEventsForDate(dateObj.date) : (getEventsForDate ? getEventsForDate(dateObj.date) : [])}
+                  todos={getTodosForDate ? getTodosForDate(dateObj.date) : []}
+                />
+              ))}
+            </div>
+          </div>
         ))}
       </div>
     </div>

--- a/frontend/src/components/calendar/DateCell.css
+++ b/frontend/src/components/calendar/DateCell.css
@@ -28,6 +28,8 @@
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-medium);
   color: var(--color-gray-900);
+  position: relative;
+  z-index: 1;
 }
 
 .date-cell--other-month .date-cell__number {
@@ -54,6 +56,11 @@
 
 .date-cell--selected:hover {
   background-color: var(--color-primary-600);
+}
+
+/* 멀티데이 바를 위한 여백 */
+.date-cell__multiday-spacer {
+  flex-shrink: 0;
 }
 
 /* 날짜 셀 하단 인디케이터 */
@@ -166,9 +173,9 @@
 /* 이벤트 바 - 갤럭시 캘린더 스타일 */
 .date-cell__event-bar {
   width: 100%;
-  padding: 2px 6px;
+  padding: 3px 6px;
   border-radius: 3px;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: var(--font-weight-medium);
   color: white;
   background-color: var(--color-primary-500);
@@ -177,10 +184,12 @@
   white-space: nowrap;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 4px;
-  transition: background-color var(--transition-base);
-  text-align: center;
+  transition: filter 0.2s;
+  text-align: left;
+  height: 18px;
+  margin: 1px 0;
 }
 
 .date-cell__event-bar:hover {
@@ -243,8 +252,8 @@
 /* 할 일 아이템 - 텍스트만 */
 .date-cell__todo-item {
   width: 100%;
-  padding: 2px 6px 2px 2px;
-  font-size: 13px;
+  padding: 3px 6px 3px 10px;
+  font-size: 10px !important;
   font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -253,15 +262,16 @@
   align-items: center;
   gap: 4px;
   position: relative;
-  padding-left: 10px;
+  height: 18px;
+  margin: 1px 0;
 }
 
 .date-cell__todo-item::before {
   content: '';
   position: absolute;
   left: 2px;
-  top: 2px;
-  bottom: 2px;
+  top: 3px;
+  bottom: 3px;
   width: 3px;
   background-color: var(--todo-bar-color, #3b82f6);
   border-radius: 1px;
@@ -271,6 +281,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 10px !important;
 }
 
 /* 더보기 버튼 */

--- a/frontend/src/components/calendar/DateCell.css
+++ b/frontend/src/components/calendar/DateCell.css
@@ -146,6 +146,8 @@
   align-self: flex-start;
   flex-shrink: 0;
   padding-left: 2px;
+  position: relative;
+  z-index: 1;
 }
 
 /* 이벤트 바 컨테이너 */
@@ -157,6 +159,8 @@
   overflow: hidden;
   flex: 1;
   min-height: 0;
+  position: relative;
+  z-index: 0;
 }
 
 /* 이벤트 바 - 갤럭시 캘린더 스타일 */
@@ -259,7 +263,7 @@
   top: 2px;
   bottom: 2px;
   width: 3px;
-  background-color: #3b82f6;
+  background-color: var(--todo-bar-color, #3b82f6);
   border-radius: 1px;
 }
 

--- a/frontend/src/components/calendar/DateCell.jsx
+++ b/frontend/src/components/calendar/DateCell.jsx
@@ -110,15 +110,17 @@ const DateCell = ({ date, isCurrentMonth, isSelected, hasEvents, hasMultiDayEven
               </div>
             );
           } else {
-            // 할일: 완료=초록색, 미완료=노란색
+            // 할일: 일정 색상 사용 (없으면 완료=초록색, 미완료=노란색)
             const todo = item.data;
-            const todoColor = todo.completed ? '#10b981' : '#eab308';
+            // schedule 객체에서 color 가져오기 (schedule.color 또는 todo.schedule_color)
+            const scheduleColor = todo.schedule?.color || todo.schedule_color;
+            const todoColor = scheduleColor || (todo.completed ? '#10b981' : '#eab308');
             
             return (
               <div
                 key={`todo-${todo.id || idx}`}
                 className="date-cell__todo-item"
-                style={{ color: todoColor }}
+                style={{ color: todoColor, '--todo-bar-color': todoColor }}
                 title={todo.title}
               >
                 <span className="todo-item__title">{todo.title}</span>

--- a/frontend/src/components/calendar/DateCell.jsx
+++ b/frontend/src/components/calendar/DateCell.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { isToday } from '../../utils/dateUtils';
 import './DateCell.css';
 
-const DateCell = ({ date, isCurrentMonth, isSelected, hasEvents, hasCompleted, hasPending, hasGoogleEvents, onClick, onDoubleClick, isFullMode = false, events = [], todos = [] }) => {
+const DateCell = ({ date, isCurrentMonth, isSelected, hasEvents, hasMultiDayEvent = false, hasCompleted, hasPending, hasGoogleEvents, onClick, onDoubleClick, isFullMode = false, events = [], todos = [] }) => {
   // 할 일 존재 여부 확인 (완료 또는 미완료)
   const hasTodos = hasCompleted || hasPending;
   const lastTapRef = useRef(0);

--- a/frontend/src/components/calendar/DateCell.jsx
+++ b/frontend/src/components/calendar/DateCell.jsx
@@ -2,11 +2,14 @@ import React, { useRef, useState } from 'react';
 import { isToday } from '../../utils/dateUtils';
 import './DateCell.css';
 
-const DateCell = ({ date, isCurrentMonth, isSelected, hasEvents, hasMultiDayEvent = false, hasCompleted, hasPending, hasGoogleEvents, onClick, onDoubleClick, isFullMode = false, events = [], todos = [] }) => {
+const DateCell = ({ date, isCurrentMonth, isSelected, hasEvents, hasMultiDayEvent = false, multiDayCount = 0, hasCompleted, hasPending, hasGoogleEvents, onClick, onDoubleClick, isFullMode = false, events = [], todos = [] }) => {
   // 할 일 존재 여부 확인 (완료 또는 미완료)
   const hasTodos = hasCompleted || hasPending;
   const lastTapRef = useRef(0);
   const [isExpanded, setIsExpanded] = useState(false);
+  
+  // 멀티데이 바 개수에 따른 상단 여백 계산 (각 바 당 20px: height 18px + margin 2px)
+  const multiDayPadding = multiDayCount > 0 ? multiDayCount * 20 : 0;
   
   const cellClass = [
     'date-cell',
@@ -182,6 +185,10 @@ const DateCell = ({ date, isCurrentMonth, isSelected, hasEvents, hasMultiDayEven
       aria-pressed={isSelected}
     >
       <span className="date-cell__number">{date.getDate()}</span>
+      {/* 멀티데이 바를 위한 여백 */}
+      {isFullMode && multiDayCount > 0 && (
+        <div className="date-cell__multiday-spacer" style={{ height: `${multiDayPadding}px` }} />
+      )}
       {isFullMode ? (
         renderDetailedEvents()
       ) : (

--- a/frontend/src/components/calendar/DateCell.jsx
+++ b/frontend/src/components/calendar/DateCell.jsx
@@ -95,8 +95,8 @@ const DateCell = ({ date, isCurrentMonth, isSelected, hasEvents, hasMultiDayEven
           if (item.type === 'event') {
             const event = item.data;
             const isGoogleEvent = event.source === 'google';
-            // 구글 일정: 빨간색, 일반 일정: 파란색
-            const eventColor = isGoogleEvent ? '#ea4335' : '#3b82f6';
+            // 이벤트 색상: 구글=빨강, 사용자 지정 색상 우선, 없으면 파란색
+            const eventColor = isGoogleEvent ? '#ea4335' : (event.color || '#3b82f6');
             
             return (
               <div

--- a/frontend/src/components/chatbot/ChatbotWindow.jsx
+++ b/frontend/src/components/chatbot/ChatbotWindow.jsx
@@ -4,15 +4,15 @@ import ChatInput from './ChatInput';
 import { getRandomLoadingMessage } from '../../hooks/useChatbot';
 import './ChatbotWindow.css';
 
-// 추천 질문 목록 - 확장 (스마트 기능 포함)
+// 추천 질문 목록 - 확장 (스마트 기능 + 이미지/URL 분석 포함)
 const suggestedQuestions = [
   { id: 1, text: '오늘 일정 요약해줘', icon: '📋', category: 'briefing' },
   { id: 2, text: '이번 주 어땠어?', icon: '📊', category: 'analysis' },
   { id: 3, text: '겹치는 일정 있어?', icon: '⚠️', category: 'conflict' },
   { id: 4, text: '과제 언제 하면 좋을까?', icon: '💡', category: 'suggest' },
-  { id: 5, text: '빈 시간 채워줘', icon: '⏰', category: 'gap' },
-  { id: 6, text: '우선순위 자동 조정해줘', icon: '🔄', category: 'priority' },
-  { id: 7, text: '할 일 추천해줘', icon: '✅', category: 'recommend' },
+  { id: 5, text: '📷 시간표 사진 분석', icon: '🖼️', category: 'image', isSpecial: true },
+  { id: 6, text: '🔗 학사일정 URL 추가', icon: '🌐', category: 'url', isSpecial: true },
+  { id: 7, text: '우선순위 자동 조정해줘', icon: '🔄', category: 'priority' },
   { id: 8, text: '내일 3시에 회의 추가해줘', icon: '📅', category: 'create' },
 ];
 
@@ -212,12 +212,19 @@ const ChatbotWindow = ({
     setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
   };
 
-  const handleSuggestedQuestion = (question) => {
-    // "시간표 사진에 있는 강의 추가해줘" 클릭 시 파일 선택 열기 (isTimetable=true)
-    if (question.includes('시간표 사진')) {
+  const handleSuggestedQuestion = (question, questionObj) => {
+    // 📷 시간표 사진 분석 클릭 시 파일 선택 열기
+    if (questionObj?.category === 'image' || question.includes('시간표 사진')) {
       handleFileUpload(true);
       return;
     }
+    
+    // 🔗 학사일정 URL 추가 클릭 시 URL 입력 안내
+    if (questionObj?.category === 'url' || question.includes('URL')) {
+      onSendMessage('학사일정이나 공모전 URL을 입력해주세요. 예: https://www.kangwon.ac.kr/www/contents.do?key=233');
+      return;
+    }
+    
     onSendMessage(question);
   };
 
@@ -346,8 +353,8 @@ const ChatbotWindow = ({
             <button
               key={q.id}
               type="button"
-              className="chatbot-window__suggestion-card"
-              onClick={() => !isDragging && handleSuggestedQuestion(q.text)}
+              className={`chatbot-window__suggestion-card ${q.isSpecial ? 'chatbot-window__suggestion-card--special' : ''}`}
+              onClick={() => !isDragging && handleSuggestedQuestion(q.text, q)}
             >
               <span className="chatbot-window__suggestion-icon">{q.icon}</span>
               <span className="chatbot-window__suggestion-text">{q.text}</span>

--- a/frontend/src/components/common/LoginModal.jsx
+++ b/frontend/src/components/common/LoginModal.jsx
@@ -40,7 +40,7 @@ const LoginModal = () => {
 
     try {
       const response = await login(formData.email, formData.password);
-      if (response.status === 200) {
+      if (response.success) {
         setFormData({ email: '', password: '' });
         closeLoginModal();
       } else {

--- a/frontend/src/components/todo/TodoFilter.css
+++ b/frontend/src/components/todo/TodoFilter.css
@@ -30,13 +30,13 @@
 }
 
 .todo-filter__select {
-  padding: var(--spacing-sm) var(--spacing-xl) var(--spacing-sm) var(--spacing-md);
+  padding: var(--spacing-sm) 36px var(--spacing-sm) var(--spacing-md);
   font-size: var(--font-size-sm);
   color: var(--color-gray-700);
   background-color: var(--color-bg-default);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 10px center;
+  background-position: right 12px center;
   border: 1px solid var(--color-gray-300);
   border-radius: var(--radius-md);
   cursor: pointer;

--- a/frontend/src/components/todo/TodoItem.jsx
+++ b/frontend/src/components/todo/TodoItem.jsx
@@ -50,6 +50,31 @@ const TodoItem = ({ todo, onToggle, onEdit, onDelete }) => {
   // 팁 (백엔드 tip 우선, 없으면 응원 문구)
   const tip = useMemo(() => getTip(todo), [todo]);
 
+  // 일정 색상 가져오기 (schedule.color 또는 기본 초록색)
+  const scheduleColor = useMemo(() => {
+    return todo.schedule?.color || todo.scheduleColor || null;
+  }, [todo]);
+
+  // 팁 배경색 계산 (일정 색상 기반 파스텔톤)
+  const tipStyle = useMemo(() => {
+    if (!scheduleColor) {
+      // 기본 초록색 스타일
+      return {
+        background: 'linear-gradient(135deg, #F0FDF4 0%, #ECFDF5 100%)',
+        borderColor: '#D1FAE5',
+        iconColor: '#10B981',
+        textColor: '#047857',
+      };
+    }
+    // 일정 색상 기반 파스텔톤 생성
+    return {
+      background: `linear-gradient(135deg, ${scheduleColor}15 0%, ${scheduleColor}20 100%)`,
+      borderColor: `${scheduleColor}40`,
+      iconColor: scheduleColor,
+      textColor: scheduleColor,
+    };
+  }, [scheduleColor]);
+
   const handleCheckboxChange = (e) => {
     e.stopPropagation();
     onToggle(todo.id, !todo.completed);
@@ -211,15 +236,21 @@ const TodoItem = ({ todo, onToggle, onEdit, onDelete }) => {
       </div>
       
       {tip && (
-        <div className="todo-item__tip">
-          <div className="tip-icon">
+        <div 
+          className="todo-item__tip"
+          style={{
+            background: tipStyle.background,
+            borderColor: tipStyle.borderColor,
+          }}
+        >
+          <div className="tip-icon" style={{ color: tipStyle.iconColor }}>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <circle cx="12" cy="12" r="10" />
               <line x1="12" y1="16" x2="12" y2="12" />
               <line x1="12" y1="8" x2="12.01" y2="8" />
             </svg>
           </div>
-          <span className="tip-text">{tip}</span>
+          <span className="tip-text" style={{ color: tipStyle.textColor }}>{tip}</span>
         </div>
       )}
     </div>

--- a/frontend/src/hooks/useCalendar.js
+++ b/frontend/src/hooks/useCalendar.js
@@ -100,23 +100,28 @@ export const useCalendar = () => {
     setSelectedDate(date);
   }, []);
 
-  // 특정 날짜의 이벤트 가져오기
+  // 특정 날짜의 이벤트 가져오기 (시작일~마감일 사이 모든 날짜 포함)
   const getEventsForDate = useCallback((date) => {
+    const targetDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    
     return events.filter(event => {
-      // startDate, date, start_at 순서로 날짜 추출
-      const dateStr = event.startDate || event.date || event.start_at || event.end_at;
-      if (!dateStr) return false;
+      // startDate, date, start_at 순서로 시작일 추출
+      const startDateStr = event.start_at || event.startDate || event.date;
+      // endDate, end_at 순서로 마감일 추출
+      const endDateStr = event.end_at || event.endDate || startDateStr;
       
-      // 날짜 문자열에서 날짜 부분만 추출 (YYYY-MM-DD)
-      const datePart = typeof dateStr === 'string' ? dateStr.split('T')[0] : null;
-      if (!datePart) return false;
+      if (!startDateStr) return false;
       
-      const [yearStr, monthStr, dayStr] = datePart.split('-');
-      return (
-        parseInt(yearStr) === date.getFullYear() &&
-        parseInt(monthStr) === date.getMonth() + 1 &&
-        parseInt(dayStr) === date.getDate()
-      );
+      // 날짜 파싱
+      const startDate = new Date(startDateStr);
+      const endDate = new Date(endDateStr);
+      
+      // 시간 부분 제거하여 날짜만 비교
+      const startOnly = new Date(startDate.getFullYear(), startDate.getMonth(), startDate.getDate());
+      const endOnly = new Date(endDate.getFullYear(), endDate.getMonth(), endDate.getDate());
+      
+      // targetDate가 시작일과 마감일 사이에 있는지 확인
+      return targetDate >= startOnly && targetDate <= endOnly;
     });
   }, [events]);
 

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -129,7 +129,7 @@
 
 .add-todo-form__select {
   width: 100%;
-  padding: 10px 12px;
+  padding: 10px 36px 10px 12px;
   font-size: 14px;
   border: 1px solid var(--color-gray-300);
   border-radius: 8px;
@@ -137,6 +137,12 @@
   color: var(--color-text-primary);
   cursor: pointer;
   transition: all 0.2s ease;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
 }
 
 .add-todo-form__select:hover {

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -2,14 +2,11 @@ import React, { useState } from 'react';
 import Calendar from '../components/calendar/Calendar';
 import TodoList from '../components/todo/TodoList';
 import TodoFilter from '../components/todo/TodoFilter';
-import ChatbotButton from '../components/chatbot/ChatbotButton';
-import ChatbotWindow from '../components/chatbot/ChatbotWindow';
 import Button from '../components/common/Button';
 import Modal from '../components/common/Modal';
 import Input from '../components/common/Input';
 import SearchableSelect from '../components/common/SearchableSelect';
 import { useTodo } from '../hooks/useTodo';
-import { useChatbot } from '../hooks/useChatbot';
 import { useCalendar } from '../hooks/useCalendar';
 import { useAuth } from '../context/AuthContext';
 import { formatDate } from '../utils/dateUtils';
@@ -47,22 +44,6 @@ const Home = () => {
 
   // 일정 목록 가져오기 (할일 추가 시 일정 선택용)
   const { events: schedules } = useCalendar();
-
-  const {
-    isOpen: isChatOpen,
-    messages,
-    loading: chatLoading,
-    messagesEndRef,
-    toggleChatbot,
-    sendMessage,
-    confirmAction,
-    cancelAction,
-    clearMessages,
-    retryLastMessage,
-    lastUserMessage,
-    selectScheduleForNotification,
-    handleChoiceSelect,
-  } = useChatbot();
 
   const handleDateSelect = (date) => {
     setSelectedDate(date);
@@ -188,24 +169,6 @@ const Home = () => {
           </div>
         </main>
       </div>
-
-      {/* Chatbot */}
-      <ChatbotButton onClick={() => requireAuth(() => toggleChatbot())} />
-      <ChatbotWindow
-        isOpen={isChatOpen}
-        onClose={toggleChatbot}
-        messages={messages}
-        onSendMessage={sendMessage}
-        loading={chatLoading}
-        messagesEndRef={messagesEndRef}
-        onConfirmAction={confirmAction}
-        onCancelAction={cancelAction}
-        onClearHistory={clearMessages}
-        onRetry={retryLastMessage}
-        canRetry={!!lastUserMessage}
-        onSelectScheduleForNotification={selectScheduleForNotification}
-        onChoiceSelect={handleChoiceSelect}
-      />
 
       {/* Add Todo Modal */}
       <Modal

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -35,7 +35,7 @@ const Login = () => {
 
     try {
       const response = await login(formData.email, formData.password);
-      if (response.status === 200) {
+      if (response.success) {
         navigate('/');
       } else {
         setError(response.message || '로그인에 실패했습니다.');

--- a/frontend/src/pages/ScheduleDetail.css
+++ b/frontend/src/pages/ScheduleDetail.css
@@ -98,6 +98,37 @@
   resize: none;
 }
 
+/* 색상 선택기 */
+.schedule-detail__color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.schedule-detail__color-option {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  padding: 0;
+}
+
+.schedule-detail__color-option:hover {
+  transform: scale(1.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.schedule-detail__color-option--selected {
+  border-color: var(--color-gray-800);
+  box-shadow: 0 0 0 2px white, 0 0 0 4px var(--color-gray-400);
+}
+
 .schedule-detail__time-row {
   display: flex;
   gap: var(--spacing-md);
@@ -143,6 +174,18 @@
   font-size: var(--font-size-base);
   color: var(--color-text-primary);
   flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* 색상 뱃지 */
+.schedule-detail__color-badge {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 /* 종일 토글 */

--- a/frontend/src/pages/ScheduleDetail.css
+++ b/frontend/src/pages/ScheduleDetail.css
@@ -55,8 +55,7 @@
 }
 
 .schedule-detail__field input,
-.schedule-detail__field textarea,
-.schedule-detail__field select {
+.schedule-detail__field textarea {
   padding: 12px 14px;
   font-size: var(--font-size-base);
   border: 1px solid var(--color-gray-200);
@@ -65,6 +64,23 @@
   font-family: inherit;
   transition: all 0.2s;
   background: white;
+}
+
+.schedule-detail__field select {
+  padding: 12px 36px 12px 14px;
+  font-size: var(--font-size-base);
+  border: 1px solid var(--color-gray-200);
+  border-radius: 10px;
+  outline: none;
+  font-family: inherit;
+  transition: all 0.2s;
+  background: white;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
 }
 
 .schedule-detail__field input:focus,
@@ -259,13 +275,19 @@
 }
 
 .schedule-detail__subtask-input select {
-  padding: 10px 12px;
+  padding: 10px 36px 10px 12px;
   font-size: var(--font-size-base);
   border: 1px solid var(--color-gray-200);
   border-radius: 8px;
   outline: none;
   background: white;
   cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
 }
 
 .schedule-detail__subtask-input input:focus,
@@ -404,9 +426,16 @@
   margin-left: var(--spacing-xs);
 }
 
-.schedule-detail__subtask-edit-input,
-.schedule-detail__subtask-edit-select {
+.schedule-detail__subtask-edit-input {
   padding: 8px 10px;
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--color-gray-200);
+  border-radius: 6px;
+  outline: none;
+}
+
+.schedule-detail__subtask-edit-select {
+  padding: 8px 36px 8px 10px;
   font-size: var(--font-size-sm);
   border: 1px solid var(--color-gray-200);
   border-radius: 6px;
@@ -422,6 +451,13 @@
 .schedule-detail__subtask-edit-select {
   background: white;
   cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 36px;
 }
 
 .schedule-detail__subtask-edit-actions {

--- a/frontend/src/pages/ScheduleDetail.jsx
+++ b/frontend/src/pages/ScheduleDetail.jsx
@@ -27,7 +27,23 @@ const ScheduleDetail = () => {
     category: '',
     priority_score: 5,
     estimated_minute: null,
+    color: '',
   });
+
+  // 일정 색상 옵션 (부드러운 파스텔톤 11가지)
+  const COLOR_OPTIONS = [
+    { value: '', label: '기본', color: '#4F8CFF' },
+    { value: '#FF6B6B', label: '코랄', color: '#FF6B6B' },
+    { value: '#FFB347', label: '오렌지', color: '#FFB347' },
+    { value: '#FFE066', label: '옐로우', color: '#FFE066' },
+    { value: '#7ED957', label: '그린', color: '#7ED957' },
+    { value: '#4ECDC4', label: '민트', color: '#4ECDC4' },
+    { value: '#4F8CFF', label: '블루', color: '#4F8CFF' },
+    { value: '#9B7EFF', label: '퍼플', color: '#9B7EFF' },
+    { value: '#FF8ED4', label: '핑크', color: '#FF8ED4' },
+    { value: '#A0A0A0', label: '그레이', color: '#A0A0A0' },
+    { value: '#8B6F47', label: '브라운', color: '#8B6F47' },
+  ];
 
   // 할 일 목록 관련 상태
   const [subTasks, setSubTasks] = useState([]);
@@ -359,6 +375,29 @@ const ScheduleDetail = () => {
                 />
               </div>
 
+              {/* 색상 선택 */}
+              <div className="schedule-detail__field">
+                <label>색상</label>
+                <div className="schedule-detail__color-picker">
+                  {COLOR_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      className={`schedule-detail__color-option ${formData.color === option.value ? 'schedule-detail__color-option--selected' : ''}`}
+                      style={{ backgroundColor: option.color }}
+                      onClick={() => setFormData(prev => ({ ...prev, color: option.value }))}
+                      title={option.label}
+                    >
+                      {formData.color === option.value && (
+                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3">
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
               <div className="schedule-detail__field">
                 <label>우선순위 (1-10)</label>
                 <input
@@ -460,6 +499,17 @@ const ScheduleDetail = () => {
                     <span className="schedule-detail__info-value">{schedule.category}</span>
                   </div>
                 )}
+                {/* 색상 표시 */}
+                <div className="schedule-detail__info-row">
+                  <span className="schedule-detail__info-label">🎨 색상</span>
+                  <span className="schedule-detail__info-value">
+                    <span 
+                      className="schedule-detail__color-badge"
+                      style={{ backgroundColor: schedule.color || '#4F8CFF' }}
+                    />
+                    {COLOR_OPTIONS.find(c => c.value === (schedule.color || ''))?.label || '기본'}
+                  </span>
+                </div>
                 <div className="schedule-detail__info-row">
                   <span className="schedule-detail__info-label">🎯 우선순위</span>
                   <span 

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -247,13 +247,13 @@
 }
 
 .settings-item__select {
-  padding: var(--spacing-sm) var(--spacing-xl) var(--spacing-sm) var(--spacing-md);
+  padding: var(--spacing-sm) 36px var(--spacing-sm) var(--spacing-md);
   font-size: 14px;
   color: var(--color-text-primary);
   background-color: var(--color-bg-default);
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 10px center;
+  background-position: right 12px center;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   cursor: pointer;
@@ -752,9 +752,11 @@
 .profile-modal__select {
   cursor: pointer;
   appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 14px center;
+  background-position: right 12px center;
   padding-right: 36px;
 }
 

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -103,10 +103,10 @@ const Signup = () => {
         formData.passwordConfirm
       );
       
-      if (response.status === 201) {
+      if (response.success) {
         // 회원가입 성공 후 자동 로그인
         const loginResponse = await login(formData.email, formData.password);
-        if (loginResponse.status === 200) {
+        if (loginResponse.success) {
           navigate('/');
         } else {
           // 자동 로그인 실패 시 로그인 페이지로

--- a/frontend/src/pages/Timetable.css
+++ b/frontend/src/pages/Timetable.css
@@ -555,12 +555,18 @@
 
 .timetable__select {
   width: 100%;
-  padding: var(--spacing-xs) var(--spacing-sm);
+  padding: var(--spacing-xs) 36px var(--spacing-xs) var(--spacing-sm);
   border: 1px solid var(--color-gray-300);
   border-radius: var(--radius-sm);
   font-size: var(--font-size-sm);
   background: white;
   cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
 }
 
 .timetable__select:focus {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -99,8 +99,8 @@ api.interceptors.response.use(
           try {
             const response = await axios.post(
               `${API_BASE_URL}/api/auth/refresh`,
-              null,
-              { params: { refresh_token: refreshToken } }
+              { refresh_token: refreshToken },
+              { headers: { 'Content-Type': 'application/json' } }
             );
             
             if (response.data.status === 200 && response.data.data) {

--- a/frontend/src/services/calendarService.js
+++ b/frontend/src/services/calendarService.js
@@ -106,6 +106,7 @@ export const createCalendarEvent = async (eventData) => {
       title: eventData.title,
       type: eventData.type || 'schedule',
       category: eventData.category || '일정',
+      color: eventData.color || null,
       start_at:
         eventData.startDate && eventData.startTime
           ? `${eventData.startDate}T${eventData.startTime}:00`
@@ -167,6 +168,8 @@ export const updateCalendarEvent = async (id, eventData) => {
       payload.update_text = eventData.description;
     if (eventData.estimated_minute !== undefined)
       payload.estimated_minute = eventData.estimated_minute;
+    if (eventData.color !== undefined)
+      payload.color = eventData.color;
 
     const response = await api.put(`/api/schedules/${id}`, payload);
     return response;


### PR DESCRIPTION
## 📋 PR 요약

챗봇 기능 강화, 멀티데이 일정 시각화, 일정 색상 선택 기능 및 전반적인 UI/UX 개선

## ✨ 주요 변경 사항

### 1. 챗봇 기능 강화
- 이미지/URL 분석으로 학사일정 자동 추출 기능 추가
- `/api/advanced/parse-url` 엔드포인트 추가
- 챗봇 아이콘을 전역 배치하여 모든 페이지에서 접근 가능
- 로그인/회원가입 페이지에서는 챗봇 숨김 처리

### 2. 멀티데이 일정 시각화
- 이번 달 달력에서 멀티데이 일정을 형광펜 바 스타일로 표시
- 시작일~마감일 전체 기간을 시각적으로 연결
- 멀티데이 바를 absolute 레이어로 분리하여 레이아웃 개선
- 각 날짜(열)에 실제로 지나가는 멀티데이 개수만큼 spacer 추가

### 3. 일정 색상 선택 기능
- Schedule 모델에 color 필드 추가 (DB 마이그레이션 포함)
- 일정 생성/수정 시 11가지 파스텔 색상 선택 가능
- 캘린더, 할 일, AI 팁 등 전체 UI에 선택한 색상 반영
- 시드 데이터에 일정 색상 추가

### 4. UI/UX 개선
- 멀티데이 바와 단일 일정 스타일 통일 (height: 18px, font-size: 12px)
- 할 일 글자 크기 10px로 축소하여 일정과 구분
- DateCell 통합 구조로 호버/선택 효과가 전체에 적용
- 날짜 숫자가 일정 위에 표시되도록 z-index 수정

### 5. 버그 수정
- Alembic multiple heads 충돌 해결
- 프론트엔드 로그인/회원가입 응답 처리 수정 (response.success 사용)
- 토큰 갱신 API 호출 방식 수정 (params → body)
- api.js 토큰 키 불일치 수정 (accessToken → auth_tokens)

## ✅ 체크리스트

- [x] 코드가 정상적으로 빌드됨
- [x] 데이터베이스 마이그레이션 포함
- [x] 시드 데이터 업데이트